### PR TITLE
PLAT-8208: Fix integration with uala-iac

### DIFF
--- a/app/controllers/deployer_controller.rb
+++ b/app/controllers/deployer_controller.rb
@@ -193,7 +193,10 @@ class DeployerController
           environment_name = env.keys[0]
           next unless environment_name == cl_app['name']
           unless settings = @envs_to_deploy.find{ |x| x['settings']['cluster_name'] == cluster['name'] }&.dig('settings')&.deep_dup
-            settings = cluster['settings'].merge(cl_app['settings'])
+            settings = cluster['settings'] || {}
+
+            settings.update(cl_app['settings']) if cl_app['settings']
+
             settings['cluster_name'] = cluster['name']
 
             auth_method = Utilities.get_cluster_auth_method(settings)


### PR DESCRIPTION
https://wahanda.atlassian.net/browse/PLAT-8208

Fix integration with `uala-iac`, which started failing after merging of https://github.com/uala/uala-iac/pull/1054.

The current fix was proved to work by the following build: https://drone.uala.dev/uala/uala-backend/35097/14/2.